### PR TITLE
Added confirmation step

### DIFF
--- a/bin/gem-reset
+++ b/bin/gem-reset
@@ -35,6 +35,7 @@ extra_gems = gemset_gems.reject do |gem|
   bundled_gems.include?(gem) || keepers.include?(gem.name)
 end
 
-puts 'extra gems:', extra_gems
+puts 'Extra gems:', extra_gems, "Remove? ('n' or ctrl-c to cancel)"
+continue = gets.chomp
 
-extra_gems.each(&:uninstall!)
+extra_gems.each(&:uninstall!) unless continue.downcase == 'n'


### PR DESCRIPTION
Currently, the script interprets error cases for 'bundle show' as no 
gems needed, which has the irritating result of uninstalling all of 
your gems. For example when you have changed a gem version in your 
Gemfile, 'bundle show' gives the error "The bundle currently has 
whatever locked at 1.1.2., Try running `bundle update whatever`" and 
this causes gem-reset to uninstall all you gems.

This commit adds a confirmation step before the gems are removed as a 
workaround to this problem. 
